### PR TITLE
Update to README for T3 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 # SplashKit Pond
 
-**SplashKit Pond** is an experimental area for testing and developing new games using the SplashKit SDK. This repository is intended for early-stage games and experimental projects that are still in development or are not yet ready for release. Once these games reach a more stable and polished state, they can progress to **SplashKit Lake** for further refinement and potential inclusion in **SplashKit Beach**.
+**SplashKit Pond** is an experimental area for testing and developing new games using the SplashKit SDK. This repository is intended for early-stage games and experimental projects that are still in development or are not yet ready for release. Once these games reach a more stable and polished state, they can progress to **[SplashKit Lake](https://github.com/thoth-tech/splashkit-lake)** for further refinement and potential inclusion in **[SplashKit Beach](https://github.com/thoth-tech/splashkit-beach)**.
 
 ## Purpose
 
-SplashKit Pond serves as a sandbox environment where developers can experiment, innovate, and test new ideas. It’s a place for creativity and exploration within the SplashKit community, allowing contributors to work on games without the constraints of a fully polished release. Games here may be incomplete, buggy, or lack certain features, as they are primarily works in progress.
+SplashKit Pond serves as a sandbox environment where developers can experiment, innovate, and test new ideas. It's a place for creativity and exploration within the SplashKit community, allowing contributors to work on games without the constraints of a fully polished release. Games here may be incomplete, buggy, or lack certain features, as they are primarily works in progress.
 
 ## Repository Structure
 
-Games within SplashKit Pond are organized as individual folders within this repository. Each folder represents a different game or experimental project, allowing contributors to explore and test new ideas independently. Once a game in SplashKit Pond becomes more stable and complete, it can be moved to **SplashKit Lake** for further refinement. From there, fully polished and stable games may advance to **SplashKit Beach** for public release in the **Arcade Machine**.
+Games within SplashKit Pond are organized as individual folders within this repository. Each folder represents a different game or experimental project, allowing contributors to explore and test new ideas independently. Once a game in SplashKit Pond becomes more stable and complete, it can be moved to **[SplashKit Lake](https://github.com/thoth-tech/splashkit-lake)** for further refinement. From there, fully polished and stable games may advance to **[SplashKit Beach](https://github.com/thoth-tech/splashkit-beach)** for public enjoyment.
 
 ## Getting Started
 
-To explore or contribute to the experimental games in SplashKit Pond, you’ll need to have the SplashKit SDK installed. Follow the [SplashKit Installation Guide](http://www.splashkit.io/installation/) to set up your environment.
+To explore or contribute to the experimental games in SplashKit Pond, you'll need to have the SplashKit SDK installed. Follow the [SplashKit Installation Guide](http://www.splashkit.io/installation/) to set up your environment.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+# SplashKit Pond
 <p align="left">
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
@@ -7,8 +8,6 @@
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit-pond?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/pulls)
 [![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit-pond?label=Forks&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/network/members)
 [![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit-pond?label=Stars&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/stargazers)
-
-# SplashKit Pond
 
 **SplashKit Pond** is an experimental area for testing and developing new games using the SplashKit SDK. This repository is intended for early-stage games and experimental projects that are still in development or are not yet ready for release. Once these games reach a more stable and polished state, they can progress to **[SplashKit Lake](https://github.com/thoth-tech/splashkit-lake)** for further refinement and potential inclusion in **[SplashKit Beach](https://github.com/thoth-tech/splashkit-beach)**.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
-![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit-pond?label=Contributors&color=F5A623)
-![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit-pond?label=Issues&color=F5A623)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit-pond?label=Pull%20Requests&color=F5A623)
-![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit-pond?label=Forks&color=F5A623)
-![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit-pond?label=Stars&color=F5A623)
+[![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit-pond?label=Contributors&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/graphs/contributors)
+[![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit-pond?label=Issues&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit-pond?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/pulls)
+[![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit-pond?label=Forks&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/network/members)
+[![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit-pond?label=Stars&color=F5A623)](https://github.com/thoth-tech/splashkit-pond/stargazers)
 
 # SplashKit Pond
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
+![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/splashkit-pond?label=Contributors&color=F5A623)
+![GitHub issues](https://img.shields.io/github/issues/thoth-tech/splashkit-pond?label=Issues&color=F5A623)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/splashkit-pond?label=Pull%20Requests&color=F5A623)
+![Forks](https://img.shields.io/github/forks/thoth-tech/splashkit-pond?label=Forks&color=F5A623)
+![Stars](https://img.shields.io/github/stars/thoth-tech/splashkit-pond?label=Stars&color=F5A623)
+
 # SplashKit Pond
 
 **SplashKit Pond** is an experimental area for testing and developing new games using the SplashKit SDK. This repository is intended for early-stage games and experimental projects that are still in development or are not yet ready for release. Once these games reach a more stable and polished state, they can progress to **[SplashKit Lake](https://github.com/thoth-tech/splashkit-lake)** for further refinement and potential inclusion in **[SplashKit Beach](https://github.com/thoth-tech/splashkit-beach)**.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# splashkit-pond
-Experimental games area. Leads to the splashkit-lake
+<p align="left">
+    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
+</p>
+
+# SplashKit Pond
+
+**SplashKit Pond** is an experimental area for testing and developing new games using the SplashKit SDK. This repository is intended for early-stage games and experimental projects that are still in development or are not yet ready for release. Once these games reach a more stable and polished state, they can progress to **SplashKit Lake** for further refinement and potential inclusion in **SplashKit Beach**.
+
+## Purpose
+
+SplashKit Pond serves as a sandbox environment where developers can experiment, innovate, and test new ideas. It’s a place for creativity and exploration within the SplashKit community, allowing contributors to work on games without the constraints of a fully polished release. Games here may be incomplete, buggy, or lack certain features, as they are primarily works in progress.
+
+## Repository Structure
+
+Games within SplashKit Pond are organized as individual folders within this repository. Each folder represents a different game or experimental project, allowing contributors to explore and test new ideas independently. Once a game in SplashKit Pond becomes more stable and complete, it can be moved to **SplashKit Lake** for further refinement. From there, fully polished and stable games may advance to **SplashKit Beach** for public release in the **Arcade Machine**.
+
+## Getting Started
+
+To explore or contribute to the experimental games in SplashKit Pond, you’ll need to have the SplashKit SDK installed. Follow the [SplashKit Installation Guide](http://www.splashkit.io/installation/) to set up your environment.
+
+## Notes
+
+Please be aware that games in this repository may be unstable, experimental, or incomplete. As such, they may not offer a fully finished gaming experience. For information on how to play or test each experimental game, refer to the README files within the specific project folders.


### PR DESCRIPTION
# Update README

## Description

This PR improves the SplashKit Pond README by defining the repository's role as an experimental environment for early-stage game projects. The changes aim to help contributors understand SplashKit Pond's function as a sandbox for innovation and provide setup instructions for new users.

## Key Updates

- **Purpose Section:** Defined SplashKit Pond as an experimental area for testing new game ideas, emphasising that games here are still in early development and may be incomplete or buggy.

- **Repository Structure:** Explained how games are organised within individual folders to facilitate independent development and testing.

- **Getting Started:** Added instructions for setting up the SplashKit SDK, including a link to the [SplashKit Installation Guide](http://www.splashkit.io/installation/).

- **GitHub Stats**: Added badges for GitHub contributors, issues, pull requests, forks, and stars for both **SplashKit** and **Thoth Tech** repositories. These stats offer an at-a-glance view of project activity and community engagement.

## Motivation

The goal of these changes is to make the README more comprehensive and user-friendly, especially for new contributors and users in preparation for Trimester 3 2024.